### PR TITLE
Issue: css always overriden

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ ActionableColumn::make('status')
 
 All standard `TextColumn` methods are available: `searchable()`, `sortable()`, `limit()`, `date()`, `formatStateUsing()`, etc.
 
+## CSS Customization
+
+To customize styles without losing changes during `composer install` or `composer update`:
+
+**Default location:** Create `resources/css/actionable-column-custom.css` (auto-detected)
+
+**Custom location:** Set `ACTIONABLE_COLUMN_CUSTOM_CSS_PATH` in `.env` or `config/actionable-column.php`
+
+The custom CSS loads after the default styles, allowing overrides without modifying published assets.
+
 ## Credits
 
 - [Shreejan][link-author]

--- a/config/actionable-column.php
+++ b/config/actionable-column.php
@@ -11,4 +11,18 @@ return [
     */
 
     'placeholder' => env('ACTIONABLE_COLUMN_PLACEHOLDER', 'N/A'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom CSS Path
+    |--------------------------------------------------------------------------
+    |
+    | Path to a custom CSS file loaded after the default styles.
+    | Prevents overwrites during composer operations.
+    | relative to the project root
+    | Ex:
+    | ACTIONABLE_COLUMN_CUSTOM_CSS_PATH=resources/css/actionable-column-custom.css
+    */
+
+    'custom_css_path' => env('ACTIONABLE_COLUMN_CUSTOM_CSS_PATH', null),
 ];

--- a/src/ActionableColumnServiceProvider.php
+++ b/src/ActionableColumnServiceProvider.php
@@ -4,6 +4,7 @@ namespace Shreejan\ActionableColumn;
 
 use Filament\Support\Assets\Css;
 use Filament\Support\Facades\FilamentAsset;
+use Illuminate\Support\Facades\File;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -22,14 +23,31 @@ class ActionableColumnServiceProvider extends PackageServiceProvider
     {
         parent::packageBooted();
 
-        FilamentAsset::register(
-            assets: [
-                Css::make(
-                    id: 'actionable-column',
-                    path: __DIR__.'/../resources/dist/css/actionable-column.css'
-                ),
-            ],
-            package: 'shreejan/actionable-column'
-        );
+        // Register default CSS first
+        $assets = [
+            Css::make('actionable-column', __DIR__.'/../resources/dist/css/actionable-column.css'),
+        ];
+
+        // Register custom CSS if provided (loads after default, allowing overrides)
+        // This solves the issue where composer install overwrites modified CSS in public/css/
+        // Custom CSS in resources/css/ won't be overwritten and loads after default CSS
+        $customCssPath = $this->getCustomCssPath();
+
+        if ($customCssPath && File::exists($customCssPath)) {
+            $assets[] = Css::make('actionable-column-custom', $customCssPath);
+        }
+
+        FilamentAsset::register($assets, package: 'shreejan/actionable-column');
+    }
+
+    protected function getCustomCssPath(): ?string
+    {
+        $configPath = config('actionable-column.custom_css_path');
+        if (! empty($configPath)) {
+            return str_starts_with($configPath, '/') ? $configPath : base_path($configPath);
+        }
+
+        $defaultPath = resource_path('css/actionable-column-custom.css');
+        return File::exists($defaultPath) ? $defaultPath : null;
     }
 }

--- a/src/ActionableColumnServiceProvider.php
+++ b/src/ActionableColumnServiceProvider.php
@@ -28,9 +28,6 @@ class ActionableColumnServiceProvider extends PackageServiceProvider
             Css::make('actionable-column', __DIR__.'/../resources/dist/css/actionable-column.css'),
         ];
 
-        // Register custom CSS if provided (loads after default, allowing overrides)
-        // This solves the issue where composer install overwrites modified CSS in public/css/
-        // Custom CSS in resources/css/ won't be overwritten and loads after default CSS
         $customCssPath = $this->getCustomCssPath();
 
         if ($customCssPath && File::exists($customCssPath)) {


### PR DESCRIPTION
 Bug Fix

Fixes the issue where `composer install` or `composer update` overwrites modified CSS in `public/css/shreejan/actionable-column/actionable-column.css`.

 📝 Usage

Option 1: Auto-detection (Recommended)
Create `resources/css/actionable-column-custom.css` - it will be automatically detected.

Option 2: Custom Path
Set `ACTIONABLE_COLUMN_CUSTOM_CSS_PATH` in your `.env` file
